### PR TITLE
Fix #2 : Attach Properties to Nodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
     <groupId>com.github.jespersm</groupId>
     <artifactId>cytoscape-gremlin</artifactId>
-    <version>0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
     <name>Cytoscape Gremlin Client App</name>
 
 	<properties>

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/CyActivator.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/CyActivator.java
@@ -179,7 +179,7 @@ public class CyActivator extends AbstractCyActivator {
         services.setVisualMappingManager(getService(context, VisualMappingManager.class));
         services.setCyEventHelper(getService(context, CyEventHelper.class));
         services.setVisualStyleFactory(getService(context, VisualStyleFactory.class));
-        services.setGremlinClient(new GremlinClient());
+        services.setGremlinClient(new GremlinClient(services));
         services.setTaskFactory(TaskFactory.create(services));
         services.setTaskExecutor(TaskExecutor.create(services));
         return services;

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/CyActivator.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/CyActivator.java
@@ -7,6 +7,7 @@ import static org.cytoscape.work.ServiceProperties.TITLE;
 
 import java.util.Properties;
 
+import com.github.jespersm.cytoscape.gremlin.internal.ui.expand.PropertyNodesMenuAction;
 import org.cytoscape.application.CyApplicationManager;
 import org.cytoscape.application.swing.CySwingApplication;
 import org.cytoscape.event.CyEventHelper;
@@ -32,10 +33,8 @@ import com.github.jespersm.cytoscape.gremlin.internal.ui.expand.ExpandNodeEdgeMe
 import com.github.jespersm.cytoscape.gremlin.internal.ui.expand.ExpandNodeLabelMenuAction;
 import com.github.jespersm.cytoscape.gremlin.internal.ui.expand.ExpandNodeMenuAction;
 import com.github.jespersm.cytoscape.gremlin.internal.ui.expand.ExpandNodesMenuAction;
-import com.github.jespersm.cytoscape.gremlin.internal.ui.exportnetwork.ExportNetworkMenuAction;
 import com.github.jespersm.cytoscape.gremlin.internal.ui.importgraph.all.ImportAllNodesAndEdgesMenuAction;
 import com.github.jespersm.cytoscape.gremlin.internal.ui.importgraph.query.ImportGremlinQueryMenuAction;
-import com.github.jespersm.cytoscape.gremlin.internal.ui.shortestpath.ShortestPathMenuAction;
 
 /**
  * This class is the entrypoint of the application,
@@ -52,6 +51,7 @@ public class CyActivator extends AbstractCyActivator {
         appConfiguration.load();
         Services services = createServices(context);
 
+        // Connect to database
         ConnectInstanceMenuAction connectAction = ConnectInstanceMenuAction.create(services);
         ImportGremlinQueryMenuAction importGremlinQueryMenuAction = ImportGremlinQueryMenuAction.create(services);
         ImportAllNodesAndEdgesMenuAction importAllNodesAndEdgesMenuAction = ImportAllNodesAndEdgesMenuAction.create(services);
@@ -60,13 +60,18 @@ public class CyActivator extends AbstractCyActivator {
 //        ExportNetworkMenuAction exportNetworkToGremlinMenuAction = ExportNetworkMenuAction.create(services);
 //        registerAllServices(context, exportNetworkToGremlinMenuAction, new Properties());
 
+        // Load initial nodes via query
         registerAllServices(context, importGremlinQueryMenuAction, new Properties());
         registerAllServices(context, importAllNodesAndEdgesMenuAction, new Properties());
+
+
+        // Connect nodes, i.e. find connection between displayed nodes
+        ConnectNodesMenuAction connectNodesMenuAction;
 
         Properties expandProperties = new Properties();
         expandProperties.setProperty(PREFERRED_MENU, "Apps.Gremlin Queries");
         expandProperties.setProperty(TITLE, "Connect all nodes");
-        ConnectNodesMenuAction connectNodesMenuAction = ConnectNodesMenuAction.create(services, false);
+        connectNodesMenuAction = ConnectNodesMenuAction.create(services, false);
         registerAllServices(context, connectNodesMenuAction, expandProperties);
 
         expandProperties = new Properties();
@@ -75,10 +80,14 @@ public class CyActivator extends AbstractCyActivator {
         connectNodesMenuAction = ConnectNodesMenuAction.create(services, true);
         registerAllServices(context, connectNodesMenuAction, expandProperties);
 
+
+        // Expand nodes i.e. find edges on nodes and follow them
+        ExpandNodesMenuAction expandNodesMenuAction;
+
         expandProperties = new Properties();
         expandProperties.setProperty(PREFERRED_MENU, "Apps.Gremlin Queries");
         expandProperties.setProperty(TITLE, "Expand all nodes, bidirectional");
-        ExpandNodesMenuAction expandNodesMenuAction = ExpandNodesMenuAction.create(services, false, Direction.BIDIRECTIONAL);
+        expandNodesMenuAction = ExpandNodesMenuAction.create(services, false, Direction.BIDIRECTIONAL);
         registerAllServices(context, expandNodesMenuAction, expandProperties);
         expandProperties.setProperty(TITLE, "Expand all nodes, incoming only");
         expandNodesMenuAction = ExpandNodesMenuAction.create(services, false, Direction.IN);
@@ -99,11 +108,27 @@ public class CyActivator extends AbstractCyActivator {
         expandNodesMenuAction = ExpandNodesMenuAction.create(services, true, Direction.OUT);
         registerAllServices(context, expandNodesMenuAction, expandProperties);
 
-        Properties shortestPathProperties = new Properties();
-        shortestPathProperties.setProperty(PREFERRED_MENU, "Apps.Gremlin Queries");
-        shortestPathProperties.setProperty(TITLE, "Get shortest paths between selected nodes");
-        ShortestPathMenuAction shortestPathMenuAction = ShortestPathMenuAction.create(services);
+
+        // Properties on nodes i.e. find edges on nodes
+        PropertyNodesMenuAction propertyNodesMenuAction;
+
+        expandProperties = new Properties();
+        expandProperties.setProperty(PREFERRED_MENU, "Apps.Gremlin Queries");
+        expandProperties.setProperty(TITLE, "Obtain properties for all nodes");
+        propertyNodesMenuAction = PropertyNodesMenuAction.create(services, false);
+        registerAllServices(context, propertyNodesMenuAction, expandProperties);
+        expandProperties.setProperty(TITLE, "Obtain properties for selected nodes");
+        propertyNodesMenuAction = PropertyNodesMenuAction.create(services, true);
+        registerAllServices(context, propertyNodesMenuAction, expandProperties);
+
+
+        // Shortest Path
+//        Properties shortestPathProperties = new Properties();
+//        shortestPathProperties.setProperty(PREFERRED_MENU, "Apps.Gremlin Queries");
+//        shortestPathProperties.setProperty(TITLE, "Get shortest paths between selected nodes");
+//        ShortestPathMenuAction shortestPathMenuAction = ShortestPathMenuAction.create(services);
 //        registerAllServices(context, shortestPathMenuAction, shortestPathProperties);
+
 
         /*
          *  Context menus
@@ -130,12 +155,12 @@ public class CyActivator extends AbstractCyActivator {
         expandNodeMenuAction = ExpandNodeMenuAction.create(services, true, Direction.OUT);
         registerAllServices(context, expandNodeMenuAction, contextProperties);
 
-        contextProperties = new Properties();
-        contextProperties.setProperty(PREFERRED_MENU, "Gremlin");
-        contextProperties.setProperty(IN_CONTEXT_MENU, "true");
-        ExpandNodeEdgeMenuAction expandNodeEdgeMenuAction = new ExpandNodeEdgeMenuAction(services);
+//        contextProperties = new Properties();
+//        contextProperties.setProperty(PREFERRED_MENU, "Gremlin");
+//        contextProperties.setProperty(IN_CONTEXT_MENU, "true");
+//        ExpandNodeEdgeMenuAction expandNodeEdgeMenuAction = new ExpandNodeEdgeMenuAction(services);
 //        registerAllServices(context, expandNodeEdgeMenuAction, contextProperties);
-        ExpandNodeLabelMenuAction expandNodeLabelMenuAction = new ExpandNodeLabelMenuAction(services);
+//        ExpandNodeLabelMenuAction expandNodeLabelMenuAction = new ExpandNodeLabelMenuAction(services);
 //        registerAllServices(context, expandNodeLabelMenuAction, contextProperties);
 
     }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/AbstractGremlinGraphFactory.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/AbstractGremlinGraphFactory.java
@@ -1,0 +1,108 @@
+package com.github.jespersm.cytoscape.gremlin.internal.client;
+
+
+import com.github.jespersm.cytoscape.gremlin.internal.graph.*;
+import org.apache.tinkerpop.gremlin.driver.Result;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public interface AbstractGremlinGraphFactory {
+
+    /**
+     * This and interface for a function class.
+     * It has only one non-static public method.
+     *
+     * @param result
+     * @return
+     */
+
+    GraphObject create(Result result);
+
+
+    static GraphObject create(Map<String,Object> elements) {
+        return elements.entrySet().stream()
+                .collect(GraphMap::new,
+                        (map, el) ->
+                                map.add(el.getKey().toString(),
+                                        create((Element)el.getValue())),
+                        (map1, map2) -> map1.merge(map2));
+    }
+
+    static GraphObject create(List<Object> objects) {
+        return objects.stream()
+                .filter(o -> o instanceof Element)
+                .map(o -> create((Element) o))
+                .collect(GraphList::new,
+                        (list, o) -> list.add(o),
+                        (list1, list2) -> list1.addAll(list2));
+    }
+
+    static GraphObject create(Element entity) {
+        if (entity instanceof Edge) {
+            return create((Edge) entity);
+        } else if (entity instanceof Vertex) {
+            return create((Vertex) entity);
+        }
+        throw new IllegalStateException();
+    }
+
+    /**
+     * When the properties in the result set need to be normalized.
+     * @param element
+     * @return
+     */
+    static Map<String, Object> toMap(Element element) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        for (String key: element.keys()) {
+            map.put(key, element.value(key));
+        }
+        return map;
+    }
+
+    /**
+     * In some cases the remote does not return with a
+     * node provisioned with it properties.
+     * In other cases it does.
+     *
+     * @param relationship
+     * @return
+     */
+    static GraphEdge create(Edge relationship) {
+        return create(relationship, toMap(relationship));
+    }
+
+    static GraphEdge create(Edge relationship, Map<String, Object> properties) {
+        GraphEdge graphEdge = new GraphEdge();
+        graphEdge.setStart(relationship.outVertex().id().toString());
+        graphEdge.setEnd(relationship.inVertex().id().toString());
+        graphEdge.setProperties(properties);
+        graphEdge.setType(relationship.label());
+        graphEdge.setId(relationship.id().toString());
+        return graphEdge;
+    }
+
+    /**
+     * In some cases the remote does not return with a
+     * node provisioned with it properties.
+     * In other cases it does.
+     *
+     * @param node
+     * @return
+     */
+
+    static GraphNode create(Vertex node) {
+        return create(node, toMap(node));
+    }
+
+    static GraphNode create(Vertex node, Map<String, Object> properties) {
+        GraphNode graphNode = new GraphNode(node.id().toString());
+        graphNode.setProperties(properties);
+        graphNode.setLabel(node.label());
+        return graphNode;
+    }
+}

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinClient.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinClient.java
@@ -12,6 +12,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.github.jespersm.cytoscape.gremlin.internal.Services;
+import com.github.jespersm.cytoscape.gremlin.internal.ui.DialogMethods;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tinkerpop.gremlin.driver.AuthProperties;
 import org.apache.tinkerpop.gremlin.driver.Client;
@@ -31,11 +33,15 @@ public class GremlinClient {
     private static final String HELLO = "hello";
     private static org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(GremlinClient.class);
 
-    
+	private final transient Services services;
     private Cluster cluster;
     private GremlinGraphFactory gremlinGraphFactory = new GremlinGraphFactory();
 
 	private String alias = "g";
+
+	public GremlinClient(Services services) {
+		this.services = services;
+	}
 
 /*
     final static Class<?> SERIALIZER = org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0.class;
@@ -102,9 +108,11 @@ public class GremlinClient {
 	}
 
 	private void ensureConnected() {
-		if (! isConnected()) { 
-    		throw new IllegalStateException("Not connected to cluster yet");
-    	}
+		if (isConnected()) { return ; }
+
+		if (!DialogMethods.connect(services)) {
+			throw new IllegalStateException("Not connected to cluster yet");
+		}
 	}
 
 	private <T> CompletableFuture<T> executeWithClient(Function<Client, CompletableFuture<T>> query, Client client) {

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinClient.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinClient.java
@@ -162,9 +162,10 @@ public class GremlinClient {
         }
     }
 
-    public void explainQuery(ScriptQuery query) throws GremlinClientException {
+    public String explainQuery(ScriptQuery query) throws GremlinClientException {
         try {
-            // TODO: session.run(query.getExplainQuery(), query.getParams());
+            // session.run(query.getExplainQuery(), query.getParams());
+			return "explainQuery not yet implemented";
         } catch (Exception e) {
             throw new GremlinClientException(e.getMessage(), e);
         }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinClient.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinClient.java
@@ -133,35 +133,25 @@ public class GremlinClient {
 		}
 	}
 
+	/**
+	 * Check all the conditions where the cluster is not open.
+	 * @return
+	 */
 	public boolean isConnected() {
-        return cluster != null && ! (cluster.isClosed() || cluster.isClosing());
-    }
-    
-    public List<Result> executeQuery(ScriptQuery query) throws GremlinClientException {
-        try {
-        	return executeQueryAsync(query).thenCompose(ResultSet::all).get();
-        } catch (Exception e) {
-            throw new GremlinClientException(e.getMessage(), e);
-        }
+    	if (cluster == null) return false;
+    	if (cluster.isClosed()) return false;
+    	if (cluster.isClosing()) return false;
+    	return true;
     }
 
     public CompletableFuture<Graph> getGraphAsync(ScriptQuery query) {
 		return executeQueryAsync(query)
-		.thenApply(result -> result
+				.thenApply(result -> result
     					.stream()
     					.map(gremlinGraphFactory::create)
     					.collect(Collectors.toList()))
     			.thenApply(Graph::createFrom);
     }
-
-    public Graph getGraph(ScriptQuery query) throws GremlinClientException {
-        try {
-        	return getGraphAsync(query).get();
-        } catch (Exception e) {
-            throw new GremlinClientException(e.getMessage(), e);
-        }
-    }
-
 
 	public CompletableFuture<Graph> explainQueryAsync(ScriptQuery query) {
 		RequestOptions.Builder builder = RequestOptions.build();
@@ -181,14 +171,6 @@ public class GremlinClient {
 				.thenApply(Graph::createFrom);
 	}
 
-
-	public Graph explainQuery(ScriptQuery query) throws GremlinClientException {
-		try {
-			return explainQueryAsync(query).get();
-		} catch (Exception e) {
-			throw new GremlinClientException(e.getMessage(), e);
-		}
-    }
 
     public void close() {
         if (isConnected()) {

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinClient.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinClient.java
@@ -144,16 +144,18 @@ public class GremlinClient {
     	return true;
     }
 
-    public CompletableFuture<Graph> getGraphAsync(ScriptQuery query) {
+    public CompletableFuture<Graph> getGraphAsync(ScriptQuery query, AbstractGremlinGraphFactory creator) {
 		return executeQueryAsync(query)
 				.thenApply(result -> result
     					.stream()
-    					.map(gremlinGraphFactory::create)
+    					.map(r -> creator.create(r))
     					.collect(Collectors.toList()))
     			.thenApply(Graph::createFrom);
     }
 
-	public CompletableFuture<Graph> explainQueryAsync(ScriptQuery query) {
+	public CompletableFuture<Graph>
+		explainQueryAsync(ScriptQuery query, AbstractGremlinGraphFactory creator)
+	{
 		RequestOptions.Builder builder = RequestOptions.build();
 		if (trimToNull(this.alias) != null) {
 			builder.addAlias("g", this.alias);
@@ -166,7 +168,7 @@ public class GremlinClient {
 		return resultSet
 				.thenApply(result -> result
 						.stream()
-						.map(gremlinGraphFactory::create)
+						.map(r -> creator.create(r))
 						.collect(Collectors.toList()))
 				.thenApply(Graph::createFrom);
 	}

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinGraphFactory.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinGraphFactory.java
@@ -12,75 +12,29 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-class GremlinGraphFactory {
+public class GremlinGraphFactory implements AbstractGremlinGraphFactory {
 
-    GraphObject create(Result result) {
-        GraphObject ret = createutil(result);
-        return ret;
-    }
-    GraphObject createutil(Result result) {
+    /**
+     * This is a function class.
+     * It has only one non-static public method declared in its interface.
+     *
+     * @param result
+     * @return
+     */
+
+    public GraphObject create(Result result) {
     	Object value = result.getObject(); 
         if (value instanceof Vertex) {
-            return create(result.getVertex());
+            return AbstractGremlinGraphFactory.create(result.getVertex());
         } else if (value instanceof Edge) {
-            return create(result.getEdge());
+            return AbstractGremlinGraphFactory.create(result.getEdge());
         } else if (value instanceof List) {
-            return create((List<Object>)value);
+            return AbstractGremlinGraphFactory.create((List<Object>)value);
         } else if (value instanceof Map) {
-            return create(((Map<String,Object>)value));
+            return AbstractGremlinGraphFactory.create(((Map<String,Object>)value));
         } else {
             return new GraphSimple(value);
         }
     }
 
-    private GraphObject create(Map<String,Object> elements) {
-        return elements.entrySet().stream()
-                .collect(GraphMap::new,
-                        (map, el) ->
-                                map.add(
-                                        el.getKey().toString(),
-                                        this.create((Element)el.getValue())),
-                        (map1, map2) -> map1.merge(map2));
-    }
-
-    private GraphObject create(List<Object> objects) {
-        return objects.stream()
-                .filter(o -> o instanceof Element)
-                .map(o -> this.create((Element) o))
-                .collect(GraphList::new, (list, o) -> list.add(o), (list1, list2) -> list1.addAll(list2));
-    }
-
-    private GraphObject create(Element entity) {
-        if (entity instanceof Edge) {
-            return create((Edge) entity);
-        } else if (entity instanceof Vertex) {
-            return create((Vertex) entity);
-        }
-        throw new IllegalStateException();
-    }
-
-    private GraphEdge create(Edge relationship) {
-        GraphEdge graphEdge = new GraphEdge();
-        graphEdge.setStart(relationship.outVertex().id().toString());
-        graphEdge.setEnd(relationship.inVertex().id().toString());
-        graphEdge.setProperties(toMap(relationship));
-        graphEdge.setType(relationship.label());
-        graphEdge.setId(relationship.id().toString());
-        return graphEdge;
-    }
-
-    private Map<String, Object> toMap(Element element) {
-    	LinkedHashMap<String, Object> map = new LinkedHashMap<>();
-    	for (String key: element.keys()) {
-    		map.put(key, element.value(key));
-    	}
-		return map;
-	}
-
-	private GraphNode create(Vertex node) {
-        GraphNode graphNode = new GraphNode(node.id().toString());
-        graphNode.setProperties(toMap(node));
-        graphNode.setLabel(node.label());
-        return graphNode;
-    }
 }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinGraphFactory.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinGraphFactory.java
@@ -15,6 +15,10 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 class GremlinGraphFactory {
 
     GraphObject create(Result result) {
+        GraphObject ret = createutil(result);
+        return ret;
+    }
+    GraphObject createutil(Result result) {
     	Object value = result.getObject(); 
         if (value instanceof Vertex) {
             return create(result.getVertex());
@@ -31,9 +35,11 @@ class GremlinGraphFactory {
 
     private GraphObject create(Map<String,Object> elements) {
         return elements.entrySet().stream()
-                .filter(e -> e.getValue() instanceof Element)
                 .collect(GraphMap::new,
-                        (map, el) -> map.add(el.getKey(), this.create((Element)el.getValue())),
+                        (map, el) ->
+                                map.add(
+                                        el.getKey().toString(),
+                                        this.create((Element)el.getValue())),
                         (map1, map2) -> map1.merge(map2));
     }
 

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinGraphImplementation.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinGraphImplementation.java
@@ -193,9 +193,9 @@ public final class GremlinGraphImplementation implements GraphImplementation {
 
     private void executeQuery(ScriptQuery theQuery) throws GraphImplementationException {
     	try {
-            gremlinClient.executeQuery(theQuery);
-        } catch (GremlinClientException e) {
-            throw new GraphImplementationException(e);
+            gremlinClient.executeQueryAsync(theQuery);
+        } catch (Exception ex) {
+            throw new GraphImplementationException(ex);
         }
     }
 

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/ScriptQuery.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/ScriptQuery.java
@@ -24,7 +24,7 @@ public class ScriptQuery {
         return query;
     }
 
-    String getExplainQuery() {
+    public String getExplainQuery() {
         return query + ".explain()";
     }
 

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/graph/Graph.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/graph/Graph.java
@@ -158,8 +158,8 @@ public class Graph implements GraphObject {
         }
 
         @Override
-        public void visit(GraphObjectList graphObjectList) {
-            graphObjectList.getList().forEach(o -> o.accept(this));
+        public void visit(GraphList graphList) {
+            graphList.getList().forEach(o -> o.accept(this));
         }
 
         @Override

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/graph/GraphList.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/graph/GraphList.java
@@ -7,7 +7,7 @@ import java.util.List;
 /**
  * This class represents a list of objects that are art of a graph.
  */
-public class GraphObjectList implements GraphObject {
+public class GraphList implements GraphObject {
 
     private List<GraphObject> list = new ArrayList<>();
 
@@ -24,7 +24,7 @@ public class GraphObjectList implements GraphObject {
         graphVisitor.visit(this);
     }
 
-    public void addAll(GraphObjectList that) {
+    public void addAll(GraphList that) {
         this.list.addAll(that.list);
     }
 }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/graph/GraphMap.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/graph/GraphMap.java
@@ -28,4 +28,10 @@ public class GraphMap implements GraphObject {
     public Collection<GraphObject> getAll() {
         return Collections.unmodifiableCollection(results.values());
     }
+
+    public GraphMap merge(GraphMap that) {
+        this.results.forEach(
+                (key, value) -> that.results.merge(key, value, (v1, v2) -> v1));
+        return this;
+    }
 }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/graph/GraphNode.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/graph/GraphNode.java
@@ -50,9 +50,6 @@ public class GraphNode implements GraphObject {
         return label;
     }
 
-    public Object getProperty(String key) {
-        return properties.get(key);
-    }
 
     public <T> Optional<T> getProperty(String key, Class<T> clz) {
         if (key != null && clz != null) {
@@ -62,22 +59,6 @@ public class GraphNode implements GraphObject {
             }
         }
         return Optional.empty();
-    }
-
-    public <T> Optional<T> getProperty(String key, Function<Object, T> fn) {
-        if (key != null && fn != null) {
-            Object value = properties.get(key);
-            if (value != null) {
-                return Optional.of(fn.apply(value));
-            }
-        }
-        return Optional.empty();
-    }
-
-    public void ifLabelPresent(String label, Consumer<String> consumer) {
-        if (this.label != null && this.label.equalsIgnoreCase(label)) {
-        	consumer.accept(this.label);
-        }
     }
 
     @Override

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/graph/GraphVisitor.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/graph/GraphVisitor.java
@@ -14,7 +14,7 @@ public interface GraphVisitor {
 
     void visit(GraphPath graphPath);
 
-    void visit(GraphObjectList graphObjectList);
+    void visit(GraphList graphList);
 
     void visit(Graph graph);
 }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractExpandNodesTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractExpandNodesTask.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.github.jespersm.cytoscape.gremlin.internal.client.GremlinGraphFactory;
 import org.codehaus.groovy.util.ListHashMap;
 import org.cytoscape.model.CyNetwork;
 import org.cytoscape.model.CyNode;
@@ -66,7 +67,7 @@ public abstract class AbstractExpandNodesTask extends AbstractGremlinNetworkTask
                 .toString();
 
         ScriptQuery scriptQuery = ScriptQuery.builder().query(query).params("ids",ids).build();
-        Graph graph = waitForGraph(taskMonitor, scriptQuery,
+        Graph graph = waitForGraph(taskMonitor, scriptQuery, new GremlinGraphFactory(),
                 "problem connecting to server");
 
         taskMonitor.setStatusMessage("Importing from Gremlin server");

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractExplainTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractExplainTask.java
@@ -1,9 +1,11 @@
 package com.github.jespersm.cytoscape.gremlin.internal.tasks;
 
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
-
+import com.github.jespersm.cytoscape.gremlin.internal.Services;
+import com.github.jespersm.cytoscape.gremlin.internal.client.GremlinClientException;
+import com.github.jespersm.cytoscape.gremlin.internal.client.ScriptQuery;
+import com.github.jespersm.cytoscape.gremlin.internal.graph.Graph;
+import com.github.jespersm.cytoscape.gremlin.internal.tasks.importgraph.ImportGraphStrategy;
+import com.github.jespersm.cytoscape.gremlin.internal.tasks.importgraph.ImportGraphToCytoscape;
 import org.cytoscape.event.CyEventHelper;
 import org.cytoscape.model.CyNetwork;
 import org.cytoscape.model.CyNode;
@@ -14,24 +16,21 @@ import org.cytoscape.view.model.View;
 import org.cytoscape.view.vizmap.VisualStyle;
 import org.cytoscape.work.TaskMonitor;
 
-import com.github.jespersm.cytoscape.gremlin.internal.Services;
-import com.github.jespersm.cytoscape.gremlin.internal.client.GremlinClientException;
-import com.github.jespersm.cytoscape.gremlin.internal.client.ScriptQuery;
-import com.github.jespersm.cytoscape.gremlin.internal.graph.Graph;
-import com.github.jespersm.cytoscape.gremlin.internal.tasks.importgraph.ImportGraphStrategy;
-import com.github.jespersm.cytoscape.gremlin.internal.tasks.importgraph.ImportGraphToCytoscape;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This class imports the results of a cyher query into cytoscape.
  */
-public abstract class AbstractImportTask extends AbstractGremlinTask {
+public abstract class AbstractExplainTask extends AbstractGremlinTask {
 
     private final String networkName;
     private final String visualStyleTitle;
     private final ImportGraphStrategy importGraphStrategy;
     private final ScriptQuery scriptQuery;
 
-    public AbstractImportTask(Services services, String networkName, String visualStyleTitle, ImportGraphStrategy importGraphStrategy, ScriptQuery scriptQuery) {
+    public AbstractExplainTask(Services services, String networkName, String visualStyleTitle, ImportGraphStrategy importGraphStrategy, ScriptQuery scriptQuery) {
         super(services);
         this.networkName = networkName;
         this.visualStyleTitle = visualStyleTitle;
@@ -44,7 +43,6 @@ public abstract class AbstractImportTask extends AbstractGremlinTask {
         try {
 
             taskMonitor.setStatusMessage("Execute query");
-            // explainQuery(scriptQuery);
 
             Graph graph = waitForRespose(scriptQuery, taskMonitor);
 

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractExplainTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractExplainTask.java
@@ -2,6 +2,7 @@ package com.github.jespersm.cytoscape.gremlin.internal.tasks;
 
 import com.github.jespersm.cytoscape.gremlin.internal.Services;
 import com.github.jespersm.cytoscape.gremlin.internal.client.GremlinClientException;
+import com.github.jespersm.cytoscape.gremlin.internal.client.GremlinGraphFactory;
 import com.github.jespersm.cytoscape.gremlin.internal.client.ScriptQuery;
 import com.github.jespersm.cytoscape.gremlin.internal.graph.Graph;
 import com.github.jespersm.cytoscape.gremlin.internal.tasks.importgraph.ImportGraphStrategy;
@@ -45,7 +46,7 @@ public abstract class AbstractExplainTask extends AbstractGremlinTask {
 
             taskMonitor.setStatusMessage("Execute query");
 
-            Graph graph = waitForGraph(taskMonitor, scriptQuery,
+            Graph graph = waitForGraph(taskMonitor, scriptQuery, new GremlinGraphFactory(),
                     "problem connecting to server");
 
             taskMonitor.setTitle("Importing the Gremlin Graph " + networkName);
@@ -95,7 +96,9 @@ public abstract class AbstractExplainTask extends AbstractGremlinTask {
 
     private void explainQuery(ScriptQuery scriptQuery) throws GremlinClientException {
         try {
-            services.getGremlinClient().explainQueryAsync(scriptQuery).get();
+            services.getGremlinClient()
+                    .explainQueryAsync(scriptQuery, new GremlinGraphFactory())
+                    .get();
         } catch (Exception ex) {
             throw new GremlinClientException(ex.getMessage(), ex);
         }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractExplainTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractExplainTask.java
@@ -19,6 +19,7 @@ import org.cytoscape.work.TaskMonitor;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * This class imports the results of a cyher query into cytoscape.
@@ -44,7 +45,8 @@ public abstract class AbstractExplainTask extends AbstractGremlinTask {
 
             taskMonitor.setStatusMessage("Execute query");
 
-            Graph graph = waitForRespose(scriptQuery, taskMonitor);
+            Graph graph = waitForGraph(taskMonitor, scriptQuery,
+                    "problem connecting to server");
 
             taskMonitor.setTitle("Importing the Gremlin Graph " + networkName);
 
@@ -92,7 +94,11 @@ public abstract class AbstractExplainTask extends AbstractGremlinTask {
     }
 
     private void explainQuery(ScriptQuery scriptQuery) throws GremlinClientException {
-        services.getGremlinClient().explainQuery(scriptQuery);
+        try {
+            services.getGremlinClient().explainQueryAsync(scriptQuery).get();
+        } catch (Exception ex) {
+            throw new GremlinClientException(ex.getMessage(), ex);
+        }
     }
 
 }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractImportTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractImportTask.java
@@ -3,6 +3,7 @@ package com.github.jespersm.cytoscape.gremlin.internal.tasks;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.cytoscape.event.CyEventHelper;
 import org.cytoscape.model.CyNetwork;
@@ -46,7 +47,8 @@ public abstract class AbstractImportTask extends AbstractGremlinTask {
             taskMonitor.setStatusMessage("Execute query");
             // explainQuery(scriptQuery);
 
-            Graph graph = waitForRespose(scriptQuery, taskMonitor);
+            Graph graph = waitForGraph(taskMonitor, scriptQuery,
+                    "problem connecting to server");
 
             taskMonitor.setTitle("Importing the Gremlin Graph " + networkName);
 
@@ -94,7 +96,11 @@ public abstract class AbstractImportTask extends AbstractGremlinTask {
     }
 
     private void explainQuery(ScriptQuery scriptQuery) throws GremlinClientException {
-        services.getGremlinClient().explainQuery(scriptQuery);
+        try {
+            services.getGremlinClient().explainQueryAsync(scriptQuery).get();
+        } catch (Exception ex) {
+            throw new GremlinClientException(ex.getMessage(), ex);
+        }
     }
 
 }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractImportTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractImportTask.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import com.github.jespersm.cytoscape.gremlin.internal.client.GremlinGraphFactory;
 import org.cytoscape.event.CyEventHelper;
 import org.cytoscape.model.CyNetwork;
 import org.cytoscape.model.CyNode;
@@ -47,7 +48,7 @@ public abstract class AbstractImportTask extends AbstractGremlinTask {
             taskMonitor.setStatusMessage("Execute query");
             // explainQuery(scriptQuery);
 
-            Graph graph = waitForGraph(taskMonitor, scriptQuery,
+            Graph graph = waitForGraph(taskMonitor, scriptQuery, new GremlinGraphFactory(),
                     "problem connecting to server");
 
             taskMonitor.setTitle("Importing the Gremlin Graph " + networkName);
@@ -97,7 +98,9 @@ public abstract class AbstractImportTask extends AbstractGremlinTask {
 
     private void explainQuery(ScriptQuery scriptQuery) throws GremlinClientException {
         try {
-            services.getGremlinClient().explainQueryAsync(scriptQuery).get();
+            services.getGremlinClient()
+                    .explainQueryAsync(scriptQuery, new GremlinGraphFactory())
+                    .get();
         } catch (Exception ex) {
             throw new GremlinClientException(ex.getMessage(), ex);
         }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractPropertyNodesTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractPropertyNodesTask.java
@@ -5,6 +5,7 @@ import com.github.jespersm.cytoscape.gremlin.internal.client.AbstractGremlinGrap
 import com.github.jespersm.cytoscape.gremlin.internal.client.GremlinGraphFactory;
 import com.github.jespersm.cytoscape.gremlin.internal.client.ScriptQuery;
 import com.github.jespersm.cytoscape.gremlin.internal.graph.Graph;
+import com.github.jespersm.cytoscape.gremlin.internal.graph.GraphNode;
 import com.github.jespersm.cytoscape.gremlin.internal.graph.GraphObject;
 import com.github.jespersm.cytoscape.gremlin.internal.graph.GraphSimple;
 import com.github.jespersm.cytoscape.gremlin.internal.tasks.importgraph.DefaultImportStrategy;
@@ -23,10 +24,7 @@ import org.cytoscape.view.model.View;
 import org.cytoscape.work.TaskMonitor;
 import org.cytoscape.work.TaskMonitor.Level;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -106,10 +104,17 @@ public abstract class AbstractPropertyNodesTask extends AbstractGremlinNetworkTa
             Object po = r.get("p");
             if (!(po instanceof Map)) { return new GraphSimple(""); }
 
-            GraphObject r2 =  AbstractGremlinGraphFactory
-                    .create((Vertex) vo,
-                            (Map<String,Object>) po);
-            return r2;
+            Vertex v = (Vertex) vo;
+            Map<String,Object> p = (Map<String,Object>) po;
+
+            Map<String,Object> q = new HashMap<>(p.size());
+            for (Map.Entry ent : p.entrySet()) {
+                if (ent.getKey().toString().equals("id")) continue;
+                if (ent.getKey().toString().equals("label")) continue;
+                Object value = ((List)ent.getValue()).get(0);
+                q.put(ent.getKey().toString(), value);
+            }
+            return  AbstractGremlinGraphFactory.create(v, q);
         }
     }
 

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractPropertyNodesTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/AbstractPropertyNodesTask.java
@@ -90,6 +90,11 @@ public abstract class AbstractPropertyNodesTask extends AbstractGremlinNetworkTa
     }
 
 
+    /**
+     * When properties are retrieved via Gremlin they may be multi-valued.
+     * Cytoscape does not support multi-valued objects (I think) so only
+     * the first element is retained.
+     */
     static class PropertyGraphFactory implements  AbstractGremlinGraphFactory {
 
         @Override

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ConnectNodesTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ConnectNodesTask.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.github.jespersm.cytoscape.gremlin.internal.client.GremlinGraphFactory;
 import org.cytoscape.model.CyNetwork;
 import org.cytoscape.model.CyRow;
 import org.cytoscape.view.model.CyNetworkView;
@@ -64,7 +65,7 @@ public class ConnectNodesTask extends AbstractGremlinNetworkTask {
                 .params("idsQuery", idsQuery)
                 .build();
 
-        Graph graph = waitForGraph(taskMonitor, scriptQuery,
+        Graph graph = waitForGraph(taskMonitor, scriptQuery, new GremlinGraphFactory(),
                 "problem connecting to server");
 
         taskMonitor.setStatusMessage("Importing the Gremlin Graph");

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ConnectNodesTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ConnectNodesTask.java
@@ -45,17 +45,17 @@ public class ConnectNodesTask extends AbstractGremlinNetworkTask {
         List<CyRow> rows = this.network.getDefaultNodeTable().getAllRows();
         Stream<CyRow> rowStream = onlySelected ? getSelectedNodes() : rows.stream();
         
-        String idsQuery = rowStream
+        List<Integer> idsQuery = rowStream
         		.map(row -> row.get(this.importGraphStrategy.getRefIDName(),String.class))
-        		.map(AbstractGremlinTask::quote)
-        		.collect(Collectors.joining(", "));
+        		.map(val -> Integer.parseInt(val))
+        		.collect(Collectors.toList());
 
         if (idsQuery.isEmpty()) {
             taskMonitor.showMessage(Level.ERROR, "No nodes selected?");
             return;
         }
-        String query = "g.V(" + idsQuery + " ).bothE().where(__.otherV().hasId(" + idsQuery + ")).dedup()";
-        ScriptQuery scriptQuery = ScriptQuery.builder().query(query).build();
+        String query = "g.V(idsQuery).bothE().where(__.otherV().hasId(idsQuery)).dedup()";
+        ScriptQuery scriptQuery = ScriptQuery.builder().query(query).params("idsQuery", idsQuery).build();
 
         Graph graph = waitForRespose(scriptQuery, taskMonitor);
 

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExpandNodeViewTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExpandNodeViewTask.java
@@ -75,10 +75,8 @@ public class ExpandNodeViewTask extends AbstractGremlinTask implements ActionLis
 		}
 		ScriptQuery scriptQuery = ScriptQuery.builder().query(query).build();
 		
-        CompletableFuture<Graph> result = CompletableFuture.supplyAsync(() -> getGraph(scriptQuery));
-        waitForRespose(scriptQuery, null);
-
-        Graph graph = result.get();
+        Graph graph = waitForGraph(null, scriptQuery,
+				"problem connecting to server");
 
         ImportGraphToCytoscape importer = new ImportGraphToCytoscape(this.netView.getModel(), importGraphStrategy, () -> this.cancelled);
 
@@ -97,14 +95,6 @@ public class ExpandNodeViewTask extends AbstractGremlinTask implements ActionLis
     public void run(TaskMonitor taskMonitor) throws Exception {
 
         taskMonitor.setTitle("Expanding a single node");
-    }
-
-    private Graph getGraph(ScriptQuery query) {
-        try {
-            return services.getGremlinClient().getGraph(query);
-        } catch (GremlinClientException e) {
-            throw new IllegalStateException(e.getMessage(), e);
-        }
     }
 
     @Override

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExpandNodeViewTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExpandNodeViewTask.java
@@ -96,7 +96,7 @@ public class ExpandNodeViewTask extends AbstractGremlinTask implements ActionLis
     @Override
     public void run(TaskMonitor taskMonitor) throws Exception {
 
-        taskMonitor.setTitle("Expanding node");
+        taskMonitor.setTitle("Expanding a single node");
     }
 
     private Graph getGraph(ScriptQuery query) {

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExpandNodeViewTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExpandNodeViewTask.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import com.github.jespersm.cytoscape.gremlin.internal.client.GremlinGraphFactory;
 import org.cytoscape.model.CyNode;
 import org.cytoscape.view.layout.CyLayoutAlgorithm;
 import org.cytoscape.view.model.CyNetworkView;
@@ -75,7 +76,7 @@ public class ExpandNodeViewTask extends AbstractGremlinTask implements ActionLis
 		}
 		ScriptQuery scriptQuery = ScriptQuery.builder().query(query).build();
 		
-        Graph graph = waitForGraph(null, scriptQuery,
+        Graph graph = waitForGraph(null, scriptQuery, new GremlinGraphFactory(),
 				"problem connecting to server");
 
         ImportGraphToCytoscape importer = new ImportGraphToCytoscape(this.netView.getModel(), importGraphStrategy, () -> this.cancelled);

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExplainQueryTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExplainQueryTask.java
@@ -1,0 +1,11 @@
+package com.github.jespersm.cytoscape.gremlin.internal.tasks;
+
+import com.github.jespersm.cytoscape.gremlin.internal.Services;
+import com.github.jespersm.cytoscape.gremlin.internal.client.ScriptQuery;
+import com.github.jespersm.cytoscape.gremlin.internal.tasks.importgraph.DefaultImportStrategy;
+
+public class ExplainQueryTask extends AbstractExplainTask {
+    public ExplainQueryTask(Services services, String networkName, String visualStyle, DefaultImportStrategy defaultImportStrategy, ScriptQuery query) {
+        super(services, networkName, visualStyle, defaultImportStrategy, query);
+    }
+}

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExportNetworkToGremlinTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExportNetworkToGremlinTask.java
@@ -47,10 +47,10 @@ public class ExportNetworkToGremlinTask extends AbstractTask {
                 );
                 Command command = getScriptQuery(cyNetwork).map(scriptQuery -> {
                     try {
-                        Graph grapInDb = services.getGremlinClient().getGraph(scriptQuery);
+                        Graph grapInDb = services.getGremlinClient().getGraphAsync(scriptQuery).get();
                         return ExportDifference.create(grapInDb, cyNetwork, graphImplementation).compute();
-                    } catch (GremlinClientException e) {
-                        throw new IllegalStateException(e);
+                    } catch (Exception ex) {
+                        throw new IllegalStateException(ex);
                     }
                 }).orElseGet(() -> ExportNew.create(cyNetwork, graphImplementation).compute());
 

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExportNetworkToGremlinTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ExportNetworkToGremlinTask.java
@@ -2,6 +2,7 @@ package com.github.jespersm.cytoscape.gremlin.internal.tasks;
 
 import java.util.Optional;
 
+import com.github.jespersm.cytoscape.gremlin.internal.client.GremlinGraphFactory;
 import org.cytoscape.model.CyNetwork;
 import org.cytoscape.work.AbstractTask;
 import org.cytoscape.work.TaskMonitor;
@@ -47,7 +48,9 @@ public class ExportNetworkToGremlinTask extends AbstractTask {
                 );
                 Command command = getScriptQuery(cyNetwork).map(scriptQuery -> {
                     try {
-                        Graph grapInDb = services.getGremlinClient().getGraphAsync(scriptQuery).get();
+                        Graph grapInDb = services.getGremlinClient()
+                                .getGraphAsync(scriptQuery, new GremlinGraphFactory())
+                                .get();
                         return ExportDifference.create(grapInDb, cyNetwork, graphImplementation).compute();
                     } catch (Exception ex) {
                         throw new IllegalStateException(ex);

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/PropertyNodesTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/PropertyNodesTask.java
@@ -1,0 +1,25 @@
+package com.github.jespersm.cytoscape.gremlin.internal.tasks;
+
+import com.github.jespersm.cytoscape.gremlin.internal.Services;
+import org.cytoscape.model.CyNetwork;
+import org.cytoscape.model.CyRow;
+
+import java.util.stream.Stream;
+
+public class PropertyNodesTask extends AbstractPropertyNodesTask {
+    private Boolean onlySelected;
+
+    public PropertyNodesTask(Services services, CyNetwork network, Boolean onlySelected) {
+        super(services, network);
+        this.onlySelected = onlySelected;
+    }
+
+    @Override
+    Stream<CyRow> getNodeRows() {
+    	if (this.onlySelected) {
+    		return getSelectedNodes();
+    	} else {
+    		return this.network.getDefaultNodeTable().getAllRows().stream();
+    	}
+	}
+}

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ShortestPathTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ShortestPathTask.java
@@ -63,7 +63,8 @@ public class ShortestPathTask extends AbstractGremlinNetworkTask implements Task
 
         ScriptQuery script = ScriptQuery.builder().query(query).build();
 
-        Graph graph = waitForRespose(script, taskMonitor, "Could not find shortest path(s). Are you still connected to the database?");
+        Graph graph = waitForGraph(taskMonitor, script,
+                "Could not find shortest path(s). Are you still connected to the database?");
 
         taskMonitor.setStatusMessage("Importing the Gremlin Graph");
         ImportGraphToCytoscape importer = new ImportGraphToCytoscape(this.network, importGraphStrategy, () -> this.cancelled);
@@ -73,14 +74,6 @@ public class ShortestPathTask extends AbstractGremlinNetworkTask implements Task
             cyNetworkView.updateView();
         }
 
-    }
-
-    private Graph getGraph(ScriptQuery query) {
-        try {
-            return services.getGremlinClient().getGraph(query);
-        } catch (GremlinClientException e) {
-            throw new IllegalStateException(e.getMessage(), e);
-        }
     }
 
 }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ShortestPathTask.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/ShortestPathTask.java
@@ -1,5 +1,6 @@
 package com.github.jespersm.cytoscape.gremlin.internal.tasks;
 
+import com.github.jespersm.cytoscape.gremlin.internal.client.GremlinGraphFactory;
 import org.cytoscape.model.CyNetwork;
 import org.cytoscape.model.CyRow;
 import org.cytoscape.task.AbstractNetworkTask;
@@ -63,7 +64,7 @@ public class ShortestPathTask extends AbstractGremlinNetworkTask implements Task
 
         ScriptQuery script = ScriptQuery.builder().query(query).build();
 
-        Graph graph = waitForGraph(taskMonitor, script,
+        Graph graph = waitForGraph(taskMonitor, script, new GremlinGraphFactory(),
                 "Could not find shortest path(s). Are you still connected to the database?");
 
         taskMonitor.setStatusMessage("Importing the Gremlin Graph");

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/TaskFactory.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/TaskFactory.java
@@ -43,4 +43,8 @@ public class TaskFactory {
     public AbstractImportTask createImportQueryTask(String networkName, ScriptQuery query, String visualStyle) {
         return new ImportQueryTask(services, networkName, visualStyle, new DefaultImportStrategy(), query);
     }
+
+    public AbstractExplainTask createExplainQueryTask(String networkName, ScriptQuery query, String visualStyle) {
+        return new ExplainQueryTask(services, networkName, visualStyle, new DefaultImportStrategy(), query);
+    }
 }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/importgraph/DefaultImportStrategy.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/importgraph/DefaultImportStrategy.java
@@ -1,5 +1,9 @@
 package com.github.jespersm.cytoscape.gremlin.internal.tasks.importgraph;
 
+import com.github.jespersm.cytoscape.gremlin.internal.graph.Graph;
+import com.github.jespersm.cytoscape.gremlin.internal.graph.GraphObject;
+
+import java.util.Map.Entry;
 import org.cytoscape.model.CyColumn;
 import org.cytoscape.model.CyEdge;
 import org.cytoscape.model.CyIdentifiable;
@@ -13,22 +17,13 @@ import com.github.jespersm.cytoscape.gremlin.internal.graph.GraphNode;
 import static com.github.jespersm.cytoscape.gremlin.internal.Constants.REF_ID;
 import static com.github.jespersm.cytoscape.gremlin.internal.Constants.CYCOLUMN_GREMLIN_LABEL;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Consumer;
 
 /**
  * This class implements an import strategy that copies all labels and properties to cytoscape
  */
-/**
- * @param cyTable
- * @param cyId
- * @param key
- * @param value
- */
+
 public class DefaultImportStrategy implements ImportGraphStrategy {
 
 
@@ -44,22 +39,25 @@ public class DefaultImportStrategy implements ImportGraphStrategy {
 
 
     @Override
-    public void createTables(CyNetwork network) {
+    public void createTables(CyNetwork network, Graph graphNode) {
         CyTable defNodeTab = network.getDefaultNodeTable();
-        if (defNodeTab.getColumn(REF_ID) == null) {
-            defNodeTab.createColumn(REF_ID, String.class, false);
-        }
-        if (defNodeTab.getColumn(CYCOLUMN_GREMLIN_LABEL) == null) {
-            defNodeTab.createColumn(CYCOLUMN_GREMLIN_LABEL, String.class, false);
+
+        createColumn(defNodeTab, REF_ID, String.class, false);
+        createColumn(defNodeTab, CYCOLUMN_GREMLIN_LABEL, String.class, false);
+        Collection<GraphNode> gn = graphNode.nodes();
+        for (GraphNode go : gn) {
+            Collection<Entry<String,Object>> entries = go.getProperties().entrySet();
+
+            for (Entry<String,Object> ent : entries) {
+                Object key = ent.getKey();
+                Class valClass = whatClass(ent.getValue());
+                createColumn(defNodeTab, key.toString(), valClass, false);
+            }
         }
 
         CyTable defEdgeTab = network.getDefaultEdgeTable();
-        if (defEdgeTab.getColumn(REF_ID) == null) {
-            defEdgeTab.createColumn(REF_ID, String.class, false);
-        }
-        if (defEdgeTab.getColumn(CYCOLUMN_GREMLIN_LABEL) == null) {
-            defEdgeTab.createColumn(CYCOLUMN_GREMLIN_LABEL, String.class, false);
-        }
+        createColumn(defEdgeTab, REF_ID, String.class, false);
+        createColumn(defEdgeTab, CYCOLUMN_GREMLIN_LABEL, String.class, false);
     }
 
     public String getRefIDName() {
@@ -69,7 +67,7 @@ public class DefaultImportStrategy implements ImportGraphStrategy {
     public void copyNode(CyNetwork network, GraphNode graphNode) {
         String nodeId = graphNode.getProperties().getOrDefault(REF_ID, graphNode.getId()).toString();
         idMap.put(graphNode.getId(), nodeId);
-        nodeMap.putIfAbsent(nodeId, graphNode);
+        nodeMap.put(nodeId, graphNode);
     }
 
     public void copyEdge(CyNetwork network, GraphEdge graphEdge) {
@@ -92,9 +90,11 @@ public class DefaultImportStrategy implements ImportGraphStrategy {
     private void saveNode(CyNetwork network, GraphNode graphNode) {
 
         String nodeId = graphNode.getProperties().getOrDefault(REF_ID, graphNode.getId()).toString();
-        if (nodeExists(network, nodeId)) {
-            return;
-        }
+
+        //
+        // if (nodeExists(network, nodeId)) {
+        //    return;
+        //}
 
         CyTable cyTable = network.getDefaultNodeTable();
         CyNode cyNode = getOrCreateNode(network, nodeId);
@@ -114,7 +114,7 @@ public class DefaultImportStrategy implements ImportGraphStrategy {
                 setEntry(cyTable, cyNode, entry.getKey(), entry.getValue());
             } else {
             	Object value = safeValue(entry.getValue());
-                createColumn(cyTable, entry.getKey(), value.getClass());
+                createColumn(cyTable, entry.getKey(), value.getClass(), true);
                 setEntry(cyTable, cyNode, entry.getKey(), value);
             }
         };
@@ -154,11 +154,11 @@ public class DefaultImportStrategy implements ImportGraphStrategy {
             if (entry.getValue() instanceof List) {
                 @SuppressWarnings("unchecked")
                 String value = createJSONArray((List<Object>) entry.getValue());
-                createColumn(cyTable, entry.getKey(), value.getClass());
+                createColumn(cyTable, entry.getKey(), value.getClass(), true);
                 setEntry(cyTable, cyEdge, entry.getKey(), value);
             } else {
             	Object value = safeValue(entry.getValue());
-                createColumn(cyTable, entry.getKey(), value.getClass());
+                createColumn(cyTable, entry.getKey(), value.getClass(), true);
                 setEntry(cyTable, cyEdge, entry.getKey(), value);
             }
         }
@@ -166,23 +166,46 @@ public class DefaultImportStrategy implements ImportGraphStrategy {
 
     /**
      * Return value which can be stored in Cytoscape
-     * 
+     *
      * @param o Value from graph
      * @return Integer, Boolean, Double, String or null
      */
     private Object safeValue(Object o) {
-		if (o instanceof String)
-			return o;
-		else if (o instanceof Integer)
-			return o;
-		else if (o instanceof Boolean)
-			return o;
-		else if (o instanceof Double)
-			return o;
-		else if (o instanceof Long)
-			return o;
-		else
-			return Objects.toString(o, "<null>");
+        if (o instanceof String)
+            return o;
+        else if (o instanceof Integer)
+            return o;
+        else if (o instanceof Boolean)
+            return o;
+        else if (o instanceof Double)
+            return o;
+        else if (o instanceof Long)
+            return o;
+        else
+            return Objects.toString(o, "<null>");
+    }
+
+    /**
+     * Return value which can be stored in Cytoscape
+     *
+     * @param o Value from graph
+     * @return Integer, Boolean, Double, String or null
+     */
+    private Class whatClass(Object o) {
+        if (o instanceof String)
+            return String.class;
+        else if (o instanceof Integer)
+            return Integer.class;
+        else if (o instanceof Boolean)
+            return Boolean.class;
+        else if (o instanceof Double)
+            return Double.class;
+        else if (o instanceof Long)
+            return Long.class;
+        else if (o instanceof List)
+            return whatClass(((List) o).get(0));
+        else
+            return Object.class;
     }
     
     private boolean edgeExists(CyNetwork network, Object id) {
@@ -205,10 +228,9 @@ public class DefaultImportStrategy implements ImportGraphStrategy {
         return cyNode;
     }
 
-    private void createColumn(CyTable cyTable, String key, Class<?> type) {
-        if (cyTable.getColumn(key) == null) {
-            cyTable.createColumn(key, type, true);
-        }
+    private void createColumn(CyTable cyTable, String key, Class<?> type, Boolean b) {
+        if (cyTable.getColumn(key) != null) { return; }
+        cyTable.createColumn(key, type, b);
     }
 
     private void createListColumn(CyTable cyTable, String key, Class<?> type) {

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/importgraph/DefaultImportStrategy.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/importgraph/DefaultImportStrategy.java
@@ -87,14 +87,17 @@ public class DefaultImportStrategy implements ImportGraphStrategy {
 
     }
 
+    /**
+     * When saving a node into the network the node may already exist.
+     * If that is the case the node is updated with its properties.
+     * Properties are not deleted but are over written.
+     *
+     * @param network
+     * @param graphNode
+     */
     private void saveNode(CyNetwork network, GraphNode graphNode) {
 
         String nodeId = graphNode.getProperties().getOrDefault(REF_ID, graphNode.getId()).toString();
-
-        //
-        // if (nodeExists(network, nodeId)) {
-        //    return;
-        //}
 
         CyTable cyTable = network.getDefaultNodeTable();
         CyNode cyNode = getOrCreateNode(network, nodeId);

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/importgraph/GraphMappingImportStrategy.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/importgraph/GraphMappingImportStrategy.java
@@ -1,5 +1,6 @@
 package com.github.jespersm.cytoscape.gremlin.internal.tasks.importgraph;
 
+import com.github.jespersm.cytoscape.gremlin.internal.graph.Graph;
 import org.cytoscape.model.CyEdge;
 import org.cytoscape.model.CyNetwork;
 import org.cytoscape.model.CyNode;
@@ -12,6 +13,7 @@ import com.github.jespersm.cytoscape.gremlin.internal.tasks.querytemplate.mappin
 import com.github.jespersm.cytoscape.gremlin.internal.tasks.querytemplate.mapping.GraphMapping;
 import com.github.jespersm.cytoscape.gremlin.internal.tasks.querytemplate.mapping.NodeColumnMapping;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -27,7 +29,7 @@ public class GraphMappingImportStrategy implements ImportGraphStrategy {
     }
 
     @Override
-    public void createTables(CyNetwork network) {
+    public void createTables(CyNetwork network, Graph graph) {
         CyTable nodeTable = network.getDefaultNodeTable();
         CyTable edgeTable = network.getDefaultEdgeTable();
 
@@ -36,6 +38,7 @@ public class GraphMappingImportStrategy implements ImportGraphStrategy {
                 nodeTable.createColumn(nodeColumnMapping.getColumnName(), nodeColumnMapping.getColumnType(), true);
             }
         }
+
         for (EdgeColumnMapping<?> edgeColumnMapping : graphMapping.getEdgeColumnMapping()) {
             if (!columnExists(edgeTable, edgeColumnMapping.getColumnName())) {
                 edgeTable.createColumn(edgeColumnMapping.getColumnName(), edgeColumnMapping.getColumnType(), true);
@@ -114,4 +117,5 @@ public class GraphMappingImportStrategy implements ImportGraphStrategy {
     public String getRefIDName() {
         return null;
     }
+
 }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/importgraph/ImportGraphStrategy.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/importgraph/ImportGraphStrategy.java
@@ -10,7 +10,8 @@ import com.github.jespersm.cytoscape.gremlin.internal.graph.GraphNode;
  * This interface specifies an import strategy for copying nodes and edges from Gremlin to Cytoscape.
  */
 public interface ImportGraphStrategy {
-    void createTables(CyNetwork network);
+
+    void createTables(CyNetwork network, Graph graph);
 
     default void copyGraph(CyNetwork network, Graph graph) {
         graph.nodes().forEach(node -> copyNode(network, node));

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/importgraph/ImportGraphToCytoscape.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/tasks/importgraph/ImportGraphToCytoscape.java
@@ -31,7 +31,7 @@ public class ImportGraphToCytoscape {
      */
     public void importGraph(Graph graph) {
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
-            importGraphStrategy.createTables(network);
+            importGraphStrategy.createTables(network, graph);
             importGraphStrategy.copyGraph(network, graph);
             importGraphStrategy.postProcess(network);
         });

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/connect/ConnectDialog.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/connect/ConnectDialog.java
@@ -129,9 +129,9 @@ class ConnectDialog extends JDialog { //NOSONAR , hierarchy level > 5
     }
 
     public static void main(String[] args) {
-        ConnectDialog connectDialog = new ConnectDialog(null, new GremlinClient()::connect, "localhost", "", 8182);
+        ConnectDialog connectDialog =
+                new ConnectDialog(null, new GremlinClient(null)::connect, "localhost", "", 8182);
         connectDialog.showConnectDialog();
-
     }
 
     public String getHostname() {

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/connect/ConnectToGremlinServer.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/connect/ConnectToGremlinServer.java
@@ -44,7 +44,8 @@ public class ConnectToGremlinServer {
         if (connectDialog.isOk()) {
             appConfiguration.setConnectionParameters(connectDialog.getHostname(), connectDialog.getUsername(), connectDialog.getPort());
             appConfiguration.save();
-            JOptionPane.showMessageDialog(this.cySwingApplication.getJFrame(), "Connected");
+        } else {
+            JOptionPane.showMessageDialog(this.cySwingApplication.getJFrame(), "Not Connected");
         }
         return gremlinClient.isConnected();
     }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/expand/ExpandNodeLabelMenuAction.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/expand/ExpandNodeLabelMenuAction.java
@@ -6,6 +6,7 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 
 import org.apache.tinkerpop.gremlin.driver.Result;
+import org.apache.tinkerpop.gremlin.driver.ResultSet;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.cytoscape.application.swing.CyMenuItem;
 import org.cytoscape.application.swing.CyNodeViewContextMenuFactory;
@@ -66,19 +67,28 @@ public class ExpandNodeLabelMenuAction implements CyNodeViewContextMenuFactory {
             this.direction = Direction.BIDIRECTIONAL;
             String query = "match (n)-[]-(r) where ID(n) = " + refid + " return distinct labels(r) as r";
             ScriptQuery scriptQuery = ScriptQuery.builder().query(query).build();
-            List<Result> result = this.services.getGremlinClient().executeQuery(scriptQuery);
+            List<Result> result = this.services.getGremlinClient()
+                    .executeQueryAsync(scriptQuery)
+                    .thenCompose(ResultSet::all)
+                    .get();
             result.forEach(this::addMenuItemsNodes);
 
             direction = Direction.IN;
             query = "match (n)<-[]-(r) where ID(n) = " + refid + " return distinct labels(r) as r";
             scriptQuery = ScriptQuery.builder().query(query).build();
-            result = this.services.getGremlinClient().executeQuery(scriptQuery);
+            result = this.services.getGremlinClient()
+                    .executeQueryAsync(scriptQuery)
+                    .thenCompose(ResultSet::all)
+                    .get();
             result.forEach(this::addMenuItemsNodes);
 
             this.direction = Direction.OUT;
             query = "match (n)-[]->(r) where ID(n) = " + refid + " return distinct labels(r) as r";
             scriptQuery = ScriptQuery.builder().query(query).build();
-            result = this.services.getGremlinClient().executeQuery(scriptQuery);
+            result = this.services.getGremlinClient()
+                    .executeQueryAsync(scriptQuery)
+                    .thenCompose(ResultSet::all)
+                    .get();
             result.forEach(this::addMenuItemsNodes);
 
 
@@ -86,7 +96,7 @@ public class ExpandNodeLabelMenuAction implements CyNodeViewContextMenuFactory {
 
             return cyMenuItem;
 
-        } catch (GremlinClientException e) {
+        } catch (Exception e) {
             e.printStackTrace();
             System.out.println(e.getMessage());
         }

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/expand/PropertyNodesMenuAction.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/expand/PropertyNodesMenuAction.java
@@ -1,0 +1,51 @@
+/**
+ *
+ */
+package com.github.jespersm.cytoscape.gremlin.internal.ui.expand;
+
+import com.github.jespersm.cytoscape.gremlin.internal.Services;
+import com.github.jespersm.cytoscape.gremlin.internal.tasks.AbstractExpandNodesTask.Direction;
+import com.github.jespersm.cytoscape.gremlin.internal.tasks.ExpandNodesTask;
+import com.github.jespersm.cytoscape.gremlin.internal.tasks.PropertyNodesTask;
+import org.cytoscape.model.CyNetwork;
+import org.cytoscape.task.NetworkTaskFactory;
+import org.cytoscape.work.TaskIterator;
+
+/**
+ * @author sven
+ */
+public class PropertyNodesMenuAction implements NetworkTaskFactory {
+
+    private static final long serialVersionUID = 1L;
+    private final transient Services services;
+    private Boolean onlySelected;
+    private Direction direction;
+
+    /**
+     *
+     */
+    public PropertyNodesMenuAction(Services services, Boolean onlySelected) {
+        this.services = services;
+        this.onlySelected = onlySelected;
+        this.direction = direction;
+    }
+
+    @Override
+    public TaskIterator createTaskIterator(CyNetwork network) {
+        if (this.isReady(network)) {
+            return new TaskIterator(new PropertyNodesTask(services, network, this.onlySelected));
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isReady(CyNetwork arg0) {
+        return arg0 != null && arg0.getNodeCount() > 0;
+    }
+
+    public static PropertyNodesMenuAction create(Services services, Boolean onlySelected) {
+        return new PropertyNodesMenuAction(services, onlySelected);
+    }
+
+}

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/importgraph/query/GremlinQueryDialog.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/importgraph/query/GremlinQueryDialog.java
@@ -20,13 +20,18 @@ import com.github.jespersm.cytoscape.gremlin.internal.ui.DialogMethods;
 @SuppressWarnings("serial")
 public class GremlinQueryDialog extends JDialog { //NOSONAR, hierarchy > 5
 
-    private static final String INITIAL_QUERY = "g.V().has(label, 'god')";
+    private static final String INITIAL_QUERY = "g.V().has('name', 'Port1')";
     private String scriptQuery;
-    private boolean executeQuery;
+    private QType qtype;
     private final String[] visualStyles;
     private String network;
     private String visualStyleTitle;
-    private boolean explainQuery;
+
+    enum QType {
+        EXPLAIN,
+        EXECUTE,
+        CANCEL
+    }
 
     public GremlinQueryDialog(Frame owner, String[] visualStyles) {
         super(owner);
@@ -58,21 +63,21 @@ public class GremlinQueryDialog extends JDialog { //NOSONAR, hierarchy > 5
 
         JButton cancelButton = new JButton("Cancel");
         cancelButton.addActionListener(e -> {
-            executeQuery = false;
+            qtype = QType.CANCEL;
             GremlinQueryDialog.this.dispose();
         });
-        JButton executButton = new JButton("Execute Query");
-        executButton.addActionListener(e -> {
-            executeQuery = true;
+        JButton executeButton = new JButton("Execute Query");
+        executeButton.addActionListener(e -> {
+            qtype = QType.EXECUTE;
             scriptQuery = queryText.getText();
             network = networkNameField.getText();
             visualStyleTitle = (String) visualStyleComboBox.getSelectedItem();
             GremlinQueryDialog.this.dispose();
         });
 
-        JButton explainButton = new JButton("Explain");
-        executButton.addActionListener(e -> {
-            explainQuery = true;
+        JButton explainButton = new JButton("Explain Query");
+        explainButton.addActionListener(e -> {
+            qtype = QType.EXPLAIN;
             scriptQuery = queryText.getText();
             network = networkNameField.getText();
             visualStyleTitle = (String) visualStyleComboBox.getSelectedItem();
@@ -89,8 +94,8 @@ public class GremlinQueryDialog extends JDialog { //NOSONAR, hierarchy > 5
         topPanel.add(visualStyleComboBox);
         queryPanel.add(queryTextScrollPane, BorderLayout.CENTER);
         buttonPanel.add(cancelButton);
-        //TODO: buttonPanel.add(explainButton);
-        buttonPanel.add(executButton);
+        buttonPanel.add(explainButton);
+        buttonPanel.add(executeButton);
 
         add(topPanel, BorderLayout.NORTH);
         add(queryPanel);
@@ -109,12 +114,8 @@ public class GremlinQueryDialog extends JDialog { //NOSONAR, hierarchy > 5
         return scriptQuery;
     }
 
-    public boolean isExecuteQuery() {
-        return executeQuery;
-    }
-
-    public boolean isExplainQuery() {
-        return explainQuery;
+    public QType whichQueryType() {
+        return this.qtype;
     }
 
     public String getNetwork() {

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/importgraph/query/GremlinQueryDialog.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/importgraph/query/GremlinQueryDialog.java
@@ -20,7 +20,8 @@ import com.github.jespersm.cytoscape.gremlin.internal.ui.DialogMethods;
 @SuppressWarnings("serial")
 public class GremlinQueryDialog extends JDialog { //NOSONAR, hierarchy > 5
 
-    private static final String INITIAL_QUERY = "g.V().has('name', 'Port1')";
+    // private static final String INITIAL_QUERY = "g.V().has('name', 'Port1').valueMap('name').with(WithOptions.tokens)";
+    private static final String INITIAL_QUERY = "g.V().has('name', 'Port1').toList()";
     private String scriptQuery;
     private QType qtype;
     private final String[] visualStyles;

--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/importgraph/query/ImportGremlinQueryMenuAction.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/ui/importgraph/query/ImportGremlinQueryMenuAction.java
@@ -1,5 +1,6 @@
 package com.github.jespersm.cytoscape.gremlin.internal.ui.importgraph.query;
 
+import com.github.jespersm.cytoscape.gremlin.internal.tasks.AbstractExplainTask;
 import org.cytoscape.application.swing.AbstractCyAction;
 import org.cytoscape.view.vizmap.VisualStyle;
 
@@ -45,48 +46,48 @@ public class ImportGremlinQueryMenuAction extends AbstractCyAction {
         handler_loop:
         do {
             gremlinQueryDialog.showDialog();
-            try {
-                switch (gremlinQueryDialog.whichQueryType()) {
-                    case CANCEL:
-                        break handler_loop;
+            switch (gremlinQueryDialog.whichQueryType()) {
+                case CANCEL:
+                    break handler_loop;
 
-                    case EXECUTE: {
-                        String query = gremlinQueryDialog.getGremlinQuery();
-                        if (query.isEmpty()) {
-                            JOptionPane.showMessageDialog(services.getCySwingApplication().getJFrame(),
-                                    "Query is empty");
-                            break;
-                        }
-                        ScriptQuery scriptQuery = ScriptQuery.builder().query(query).build();
-                        AbstractImportTask executeImportTask =
-                                services.getTaskFactory().createImportQueryTask(
-                                        gremlinQueryDialog.getNetwork(),
-                                        scriptQuery,
-                                        gremlinQueryDialog.getVisualStyleTitle()
-                                );
-                        services.getTaskExecutor().execute(executeImportTask);
-                    } break handler_loop;
-
-                    case EXPLAIN: {
-                        String query = gremlinQueryDialog.getGremlinQuery();
-                        if (query.isEmpty()) {
-                            JOptionPane.showMessageDialog(services.getCySwingApplication().getJFrame(),
-                                    "Query is empty");
-                            break;
-                        }
-                        ScriptQuery scriptQuery = ScriptQuery.builder().query(query).build();
-                        String res = services.getGremlinClient().explainQuery(scriptQuery);
+                case EXECUTE: {
+                    String query = gremlinQueryDialog.getGremlinQuery();
+                    if (query.isEmpty()) {
                         JOptionPane.showMessageDialog(services.getCySwingApplication().getJFrame(),
-                                res);
-                    } break handler_loop;
+                                "Query is empty");
+                        break;
+                    }
+                    ScriptQuery scriptQuery = ScriptQuery.builder().query(query).build();
+                    AbstractImportTask executeImportTask =
+                            services.getTaskFactory().createImportQueryTask(
+                                    gremlinQueryDialog.getNetwork(),
+                                    scriptQuery,
+                                    gremlinQueryDialog.getVisualStyleTitle()
+                            );
+                    services.getTaskExecutor().execute(executeImportTask);
+                } break handler_loop;
 
-                    default:
+                case EXPLAIN: {
+                    String query = gremlinQueryDialog.getGremlinQuery();
+                    if (query.isEmpty()) {
                         JOptionPane.showMessageDialog(services.getCySwingApplication().getJFrame(),
-                                String.format("Unknown query type %s", gremlinQueryDialog.whichQueryType()));
+                                "Query is empty");
+                        break;
+                    }
+                    ScriptQuery scriptQuery = ScriptQuery.builder().query(query).build();
+                    AbstractExplainTask executeExplainTask =
+                            services.getTaskFactory().createExplainQueryTask(
+                                    gremlinQueryDialog.getNetwork(),
+                                    scriptQuery,
+                                    gremlinQueryDialog.getVisualStyleTitle()
+                            );
+                    services.getTaskExecutor().execute(executeExplainTask);
+                } break handler_loop;
 
-                }
-            } catch (GremlinClientException e1) {
-                JOptionPane.showMessageDialog(services.getCySwingApplication().getJFrame(), e1.getMessage());
+                default:
+                    JOptionPane.showMessageDialog(services.getCySwingApplication().getJFrame(),
+                            String.format("Unknown query type %s", gremlinQueryDialog.whichQueryType()));
+
             }
             gremlinQueryDialog = new GremlinQueryDialog(
                     services.getCySwingApplication().getJFrame(),

--- a/src/test-it/java/com/github/jespersm/cytoscape/gremlin/internal/CyGremlinGraphIT.java
+++ b/src/test-it/java/com/github/jespersm/cytoscape/gremlin/internal/CyGremlinGraphIT.java
@@ -86,7 +86,7 @@ public class CyGremlinGraphIT {
 
         Steps.newInstance(gremlinClient)
                 .givenRandomNetwork()
-                .whenImportQuery("g.V().has(label, 'god')")
+                .whenImportQuery("g.V().has('label', 'mortal')")
                 .thenGraphHas("All nodes should be imported", 3, Steps.Types.NODES)
                 .thenGraphHas("No edges should be imported", 0, Steps.Types.EDGES)
                 .thenNetworkHas(3, Steps.Types.NODES)


### PR DESCRIPTION
The primary motivation was to pull and present the node properties.
The creation of node properties was widely separated from the request for those properties.
see AbstractProperyNodesTask.java for an example of how they are now placed into the same java class.

There is also more work done on getting the explain behavior working  #3  but that is as yet incomplete.

There are some other minor improvements which revealed themselves during debugging.
For example the cluster connection and re-connection required several unnecessary clicks (Inform me when things fail not when they succeed).

There are still a lot of features to complete not to mention testing but it is already sufficient for my immediate needs.
