### PR TITLE
Bug fix when passing username and password

### DIFF
--- a/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinClient.java
+++ b/src/main/java/com/github/jespersm/cytoscape/gremlin/internal/client/GremlinClient.java
@@ -60,8 +60,8 @@ public class GremlinClient {
         	}
         	String userName = StringUtils.trimToNull(connectionParameter.getUsername());
 			if (userName != null) {
-        		builder = builder.authProperties(new AuthProperties().with(USERNAME, userName));
-        		builder = builder.authProperties(new AuthProperties().with(PASSWORD, connectionParameter.getPasswordAsString()));
+        		builder = builder.authProperties(new AuthProperties().with(USERNAME, userName)
+				                                                     .with(PASSWORD, connectionParameter.getPasswordAsString()));
         	}
 			
 	        HashMap<String, Object> configMap = new HashMap<>();


### PR DESCRIPTION
Hello!

There is a bug if the username and password parameters are passed.
The authProperties method is called twice and the second call overrides the first one. Thats because a new instance of AuthProperties is passed, so the username is never set.
I hope this can help.

Thank you!